### PR TITLE
Add tag configuration to format message tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A tag of messages from AWS firelens has format like `[containerName]-firelens-[taskID]`, but a tag of fluentd is a string separated by dots (e.g. myapp.access) usually.
 
-fluent-plugin-firelens-tag-filter rewrites message tags from `[containerName]-firelens-[taskID]` to `[tag_prefix].[containerName].(stdout|stderr).[taskID]`.
+fluent-plugin-firelens-tag-filter rewrites message tags from `[containerName]-firelens-[taskID]` to `[tag_prefix].[containerName].(stdout|stderr).[taskID]` by default.
 
 ## Installation
 
@@ -46,6 +46,25 @@ $ bundle
   # ...
 </match>
 ```
+
+Customize `tag` format.
+
+```conf
+<match *-firelens-*>
+  @type firelens_tag_filter
+  tag ${container_name}.${source}
+</match>
+
+<match app.stdout>
+  # ...
+</match>
+```
+
+Placeholders allowed in tag as below.
+
+- ${container-name} : Container name in task.
+- ${task_id} : ECS task ID
+- ${source} : source field in record (`stdout` or `stderr`)
 
 ## Copyright
 

--- a/example.conf
+++ b/example.conf
@@ -16,3 +16,9 @@
 <match **>
   @type stdout
 </match>
+
+<label @FLUENT_LOG>
+  <match **>
+    @type null
+  </match>
+</label>

--- a/test/plugin/test_out_firelens_tag_filter.rb
+++ b/test/plugin/test_out_firelens_tag_filter.rb
@@ -38,6 +38,22 @@ class FirelensTagFilterOutputTest < Test::Unit::TestCase
     assert_equal events[2], ['ecs.app.unknown.a27287f301b06d77', time, {"foo" => "boo"}]
   end
 
+  test "tag" do
+    d = create_driver "tag xxx.${source}.${task_id}.${container_name}"
+    time = event_time("2020-07-22 11:22:33Z")
+    d.run(default_tag: "app-firelens-a27287f301b06d77") do
+      d.feed(time, {"foo" => "bar", "source" => "stdout"})
+      d.feed(time, {"foo" => "baz", "source" => "stderr"})
+      d.feed(time, {"foo" => "boo"})
+    end
+
+    events = d.events
+    assert_equal 3, events.length
+    assert_equal events[0], ['xxx.stdout.a27287f301b06d77.app', time, {"foo" => "bar", "source" => "stdout"}]
+    assert_equal events[1], ['xxx.stderr.a27287f301b06d77.app', time, {"foo" => "baz", "source" => "stderr"}]
+    assert_equal events[2], ['xxx.unknown.a27287f301b06d77.app', time, {"foo" => "boo"}]
+  end
+
   test "unexpected" do
     d = create_driver ""
     time = event_time("2020-07-22 11:22:33Z")


### PR DESCRIPTION
In some use-cases, we hope to customize `tag` format.

```conf
<match *-firelens-*>
  @type firelens_tag_filter
  tag ${container_name}.${source}
</match>

<match app.stdout>
  # ...
</match>
```